### PR TITLE
Add testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: all plan apply destroy
+SHELL := $(SHELL) -e
 
 all: plan apply
 
@@ -16,3 +17,7 @@ destroy:
 clean:
 	rm -f terraform.tfplan
 	rm -f terraform.tfstate
+
+
+test:
+	./scripts/testPlan

--- a/scripts/testPlan
+++ b/scripts/testPlan
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+exitcode=0
+TFILE=`mktemp`
+GREEN="\e[1;34m"
+RED="\e[0;31m"
+RESET="\e[0m"
+
+# $1 = exit code (will exit testing if non-zero)
+# $2 = description of the test
+# $3 = output of the test
+CLEANUP () {
+  rm -f $TFILE
+  if [ $1 -ne 0 ]; then
+    echo -e "$RED test '$2' failed: $RESET\n $3"
+    exit $1
+  fi
+}
+
+desc="Can we find the terraform binary?"
+OUTPUT=$(which terraform)
+CLEANUP "$?" "$desc" "Couldn't find terraform. Is it in your PATH?"
+
+desc="Does the plan compile?"
+OUTPUT=$(terraform plan -var-file terraform.tfvars.example)
+CLEANUP "$?" "$desc" "$OUTPUT"
+
+desc="Did the baseline terraform plan change?"
+terraform plan -var-file terraform.tfvars.example &> $TFILE
+OUTPUT=$(diff test-fixtures/terraform.tfplan $TFILE)
+CLEANUP "$?" "$desc" "$OUTPUT"
+
+# If we got here, all the tests passed
+echo -e "$GREEN All tests passed $RESET"
+exit 0

--- a/terraform.tfvars.example
+++ b/terraform.tfvars.example
@@ -1,5 +1,5 @@
-aws_access_key = ""
-aws_secret_key = ""
+aws_access_key = "XXXXXXXXXXXXXXX"
+aws_secret_key = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
 aws_key_path = "~/.ssh/bosh-us-east-1.pem"
 aws_key_name = "bosh"
 aws_region = "us-east-1"


### PR DESCRIPTION
Add a `test` target to the make file, add `-e` to the shell that Makefile uses to quick-fail, update terraform.tfvars.example to have "real" values for `aws_access_key` and `aws_secret_key` so that terraform will compile the test plan, and finally add `scripts/testPlan` to actually perform the testing.