### PR TITLE
Allow all outbound traffic for nat and bastion security_groups

### DIFF
--- a/aws-vpc.tf
+++ b/aws-vpc.tf
@@ -81,6 +81,13 @@ resource "aws_security_group" "nat" {
 		protocol = "icmp"
 	}
 
+	egress {
+		from_port = 0
+		to_port = 65535
+		protocol = "-1"
+		cidr_blocks = ["0.0.0.0/0"]
+	}
+
 	tags {
 		Name = "${var.aws_vpc_name}-nat"
 	}
@@ -209,6 +216,13 @@ resource "aws_security_group" "bastion" {
 		from_port = -1
 		to_port = -1
 		protocol = "icmp"
+	}
+
+	egress {
+		from_port = 0
+		to_port = 65535
+		protocol = "-1"
+		cidr_blocks = ["0.0.0.0/0"]
 	}
 
 	tags {

--- a/test-fixtures/terraform.testplan
+++ b/test-fixtures/terraform.testplan
@@ -73,7 +73,14 @@ Note: You didn't specify an "-out" parameter to save this plan, so when
 [0m
 [0m[32m+ aws_security_group.bastion
 [0m    description:                          "" => "Allow SSH traffic from the internet"
-    egress.#:                             "" => "<computed>"
+    egress.#:                             "" => "1"
+    egress.532441254.cidr_blocks.#:       "" => "1"
+    egress.532441254.cidr_blocks.0:       "" => "0.0.0.0/0"
+    egress.532441254.from_port:           "" => "0"
+    egress.532441254.protocol:            "" => "-1"
+    egress.532441254.security_groups.#:   "" => "0"
+    egress.532441254.self:                "" => "0"
+    egress.532441254.to_port:             "" => "65535"
     ingress.#:                            "" => "4"
     ingress.1799340084.cidr_blocks.#:     "" => "1"
     ingress.1799340084.cidr_blocks.0:     "" => "0.0.0.0/0"
@@ -109,7 +116,14 @@ Note: You didn't specify an "-out" parameter to save this plan, so when
 [0m
 [0m[32m+ aws_security_group.nat
 [0m    description:                          "" => "Allow services from the private subnet through NAT"
-    egress.#:                             "" => "<computed>"
+    egress.#:                             "" => "1"
+    egress.532441254.cidr_blocks.#:       "" => "1"
+    egress.532441254.cidr_blocks.0:       "" => "0.0.0.0/0"
+    egress.532441254.from_port:           "" => "0"
+    egress.532441254.protocol:            "" => "-1"
+    egress.532441254.security_groups.#:   "" => "0"
+    egress.532441254.self:                "" => "0"
+    egress.532441254.to_port:             "" => "65535"
     ingress.#:                            "" => "7"
     ingress.1431762526.cidr_blocks.#:     "" => "1"
     ingress.1431762526.cidr_blocks.0:     "" => "0.0.0.0/0"


### PR DESCRIPTION
When I spun up a new AWS VPC in us-east-1 today (using terraform 0.5.0), the `nats` and `bastion` SG created had NO outbound rules.

This meant that the bastion server failed to initialise, since `apt get` didn't work.

I think its a bug that these SG groups had no outbound rules defined; so this PR adds rules that allow all outbound traffic.

I'm not sure that is the correct outbound rule to add; but it does allow the bastion server to be successfully provisioned.